### PR TITLE
Fix Mac key binding for 'sanity.executeGroq' to not conflict with VSCode keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       {
         "command": "sanity.executeGroq",
         "key": "ctrl+shift+g",
-        "mac": "cmd+shift+g",
+        "mac": "ctrl+shift+g",
         "when": "editorTextFocus"
       }
     ]


### PR DESCRIPTION
Fixes #5.