### PR TITLE
fix: add error that sanity.cli config is not supported

### DIFF
--- a/src/config/findConfig.ts
+++ b/src/config/findConfig.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 import os from 'os'
-import {promises as fs} from 'fs'
+import { promises as fs } from 'fs'
 import osenv from 'osenv'
 import xdgBasedir from 'xdg-basedir'
 
@@ -11,15 +11,19 @@ export interface Config {
   token?: string
 }
 
+type ConfigFileName = 'sanity.cli.ts' | 'sanity.cli.js' | 'sanity.json'
+
 export async function loadConfig(basePath: string): Promise<Config | false> {
   let dir = basePath
-  while (!(await hasConfig(dir))) {
+  let configFile = await hasConfig(dir)
+  while (!configFile) {
     const parent = path.dirname(dir)
     if (!dir || parent === dir) {
       // last ditch effort, check if we are in a studio monorepo
       const folders = vscode?.workspace?.workspaceFolders || []
       dir = (folders.length && folders[0].uri.fsPath + '/studio') || '/'
-      if (!(await hasConfig(dir))) {
+      configFile = await hasConfig(dir)
+      if (!configFile) {
         return false
       }
     } else {
@@ -27,7 +31,11 @@ export async function loadConfig(basePath: string): Promise<Config | false> {
     }
   }
 
-  const configContent = await fs.readFile(path.join(dir, 'sanity.json'), 'utf8')
+  if (configFile === 'sanity.cli.ts' || configFile === 'sanity.cli.js') {
+    throw new Error('Sanity Studio V3 is not supported in this extension')
+  }
+
+  const configContent = await fs.readFile(path.join(dir, configFile), 'utf8')
   const config = parseJson(configContent)
   if (!config || !config.api || !config.api.projectId) {
     return false
@@ -36,14 +44,21 @@ export async function loadConfig(basePath: string): Promise<Config | false> {
   const cliConfigContent = await fs.readFile(getGlobalConfigLocation(), 'utf8')
   const cliConfig = parseJson(cliConfigContent)
 
-  return cliConfig ? {...config.api, token: cliConfig.authToken} : config.api
+  return cliConfig ? { ...config.api, token: cliConfig.authToken } : config.api
 }
 
-async function hasConfig(dir: string): Promise<boolean> {
-  return fs
-    .stat(path.join(dir, 'sanity.json'))
-    .then(() => true)
-    .catch(() => false)
+async function hasConfig(dir: string): Promise<ConfigFileName | undefined> {
+  const configFiles: ConfigFileName[] = ['sanity.cli.ts', 'sanity.cli.js', 'sanity.json']
+  for (const configFile of configFiles) {
+    const exists = await fs
+      .stat(path.join(dir, configFile))
+      .then(() => true)
+      .catch(() => false)
+    if (exists) {
+      return configFile
+    }
+  }
+  return undefined
 }
 
 function parseJson(content: string) {


### PR DESCRIPTION
This patch adds a more helpful error message that Sanity V3 is not supported in this extension

![Screenshot 2024-04-11 at 14 43 26](https://github.com/sanity-io/vscode-sanity/assets/38528/643f3c57-8835-48a2-9c32-850b091a70b8)
