### PR TITLE
fix: add contentName to defineQuery so its treated as GROQ

### DIFF
--- a/grammars/groq.js.json
+++ b/grammars/groq.js.json
@@ -61,6 +61,7 @@
     {
       "name": "meta.embedded.block.defineQuery",
       "begin": "(defineQuery)\\s*\\(\\s*(['\"`])",
+      "contentName": "meta.embedded.block.groq",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-sanity",
   "displayName": "Sanity.io",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "description": "Developer tools for applications powered by Sanity.io",
   "author": "Sanity.io <hello@sanity.io>",


### PR DESCRIPTION
Without content name the language of the tokens aren't interpreted as GROQ.
Before:
![image](https://github.com/user-attachments/assets/33ddcd3a-5206-4177-b437-303c8f6b1cb2)

After:
![image](https://github.com/user-attachments/assets/7e7aefdd-2505-40bc-b96c-0ccbb07e0da2)
