### PR TITLE
Add copy query command

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,20 @@
       {
         "command": "sanity.executeGroq",
         "title": "Execute GROQ query"
+      },
+      {
+        "command": "sanity.copyGroq",
+        "title": "Copy GROQ query"
       }
     ],
     "menus": {
       "commandPalette": [
         {
           "command": "sanity.executeGroq",
+          "when": "editorLangId == groq || editorLangId == plaintext"
+        },
+        {
+          "command": "sanity.copyGroq",
           "when": "editorLangId == groq || editorLangId == plaintext"
         }
       ]

--- a/src/providers/groq-codelens-provider.ts
+++ b/src/providers/groq-codelens-provider.ts
@@ -1,4 +1,11 @@
-import {type CodeLensProvider, type TextDocument, type CancellationToken, CodeLens, Range, Position} from 'vscode'
+import {
+  type CodeLensProvider,
+  type TextDocument,
+  type CancellationToken,
+  CodeLens,
+  Range,
+  Position,
+} from 'vscode'
 
 interface ExtractedQuery {
   content: string
@@ -30,7 +37,7 @@ function extractAllDefineQuery(document: TextDocument): ExtractedQuery[] {
   const documents: ExtractedQuery[] = []
   const text = document.getText()
   const pattern = '(\\s*defineQuery\\((["\'`])([\\s\\S]*?)\\2\\))'
-  const regexp = new RegExp(pattern, 'g');
+  const regexp = new RegExp(pattern, 'g')
 
   let prevIndex = 0
   let result
@@ -58,22 +65,40 @@ export class GROQCodeLensProvider implements CodeLensProvider {
           command: 'sanity.executeGroq',
           arguments: [document.getText()],
         }),
+        new CodeLens(new Range(new Position(0, 0), new Position(0, 0)), {
+          title: 'Copy Query',
+          command: 'sanity.copyGroq',
+          arguments: [document.getText()],
+        }),
       ]
     }
 
     // find all lines where "groq" exists
-    const queries: ExtractedQuery[] = [...extractAllTemplateLiterals(document), ...extractAllDefineQuery(document)]
+    const queries: ExtractedQuery[] = [
+      ...extractAllTemplateLiterals(document),
+      ...extractAllDefineQuery(document),
+    ]
 
-    // add a button above each line that has groq
-    return queries.map((def) => {
-      return new CodeLens(
-        new Range(new Position(def.position.line, 0), new Position(def.position.line, 0)),
-        {
-          title: 'Execute Query',
-          command: 'sanity.executeGroq',
-          arguments: [def.content],
-        }
-      )
+    // add a buttons above each line that has groq
+    return queries.flatMap((def) => {
+      return [
+        new CodeLens(
+          new Range(new Position(def.position.line, 0), new Position(def.position.line, 0)),
+          {
+            title: 'Execute Query',
+            command: 'sanity.executeGroq',
+            arguments: [def.content],
+          },
+        ),
+        new CodeLens(
+          new Range(new Position(def.position.line, 0), new Position(def.position.line, 0)),
+          {
+            title: 'Copy Query',
+            command: 'sanity.copyGroq',
+            arguments: [def.content],
+          },
+        ),
+      ]
     })
   }
 }


### PR DESCRIPTION
### Description

This adds a new 'Copy Query' command next to the 'Execute Query'. I often found my self simply wanting to copy the query instead of executing it.

### What to review

Most of the logic is in `extension.ts` which adds the `sanity.copyGroq` command. After a successful  copy, a status bar message is shown. I figured a status bar message is better than full notification message in this scenario. 

Looks like some of the files weren't fully formatted according to the Prettier rules, so a few extra formatting changes got included.