### PR TITLE
Format JSON before opening

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -239,7 +239,7 @@ async function readParams(variables: string[]): Promise<Record<string, unknown>>
 }
 
 async function openInUntitled(content: string, language?: string) {
-  const cs = JSON.stringify(content)
+  const cs = JSON.stringify(content, null, 2)
   await vscode.workspace.openTextDocument({content: cs}).then((document) => {
     vscode.window.showTextDocument(document, {viewColumn: vscode.ViewColumn.Beside})
     vscode.languages.setTextDocumentLanguage(document, language || 'json')


### PR DESCRIPTION
### Description

This is a small QoL change which will format the JSON before opening it when using the 'Open JSON file' option.
The 'Open JSON file' option is great, as it is just a standard editor in VSCode. I can collapse blocks, search for text and it will just use my colour theme out of the box, but the lack of formatting makes it a bit annoying to use.


### What to review

Only a couple of params is added to `JSON.stringify`, so this should be a fairly safe change.
