### PR TITLE
ci(release): fix typo in npm command in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
-      - run: npm release
+      - run: npm run release


### PR DESCRIPTION
### Description

Fix a typo in the github workflow that was overlooked in dev and review. `npm release` should have been `npm run release`